### PR TITLE
feat: introduce pinia store register code action

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,18 @@
                     "command": "findComponentReferences"
                 }
             ]
-        }
+        },
+        "codeActions": [
+            {
+                "actions": {
+                    "title": "Register pinia store in computed",
+                    "kind": "QuickFix"
+                },
+                "languages": [
+                    "vue"
+                ]
+            }
+        ]
     },
     "activationEvents": [
         "onLanguage:vue"

--- a/package.json
+++ b/package.json
@@ -55,18 +55,7 @@
                     "command": "findComponentReferences"
                 }
             ]
-        },
-        "codeActions": [
-            {
-                "actions": {
-                    "title": "Register pinia store in computed",
-                    "kind": "QuickFix"
-                },
-                "languages": [
-                    "vue"
-                ]
-            }
-        ]
+        }
     },
     "activationEvents": [
         "onLanguage:vue"
@@ -77,7 +66,7 @@
     },
     "devDependencies": {
         "@types/node": "^17.0.21",
-        "@types/vscode": "^1.65.0",
+        "@types/vscode": "^1.72.0",
         "@zardoy/tsconfig": "^1.4.0",
         "eslint": "^8.10.0",
         "eslint-config-zardoy": "^0.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,7 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@types/node': ^17.0.21
-  '@types/vscode': ^1.65.0
+  '@types/vscode': ^1.72.0
   '@zardoy/tsconfig': ^1.4.0
   '@zardoy/utils': ^0.0.9
   '@zardoy/vscode-utils': ^0.0.29
@@ -22,7 +22,7 @@ specifiers:
 
 dependencies:
   '@zardoy/utils': 0.0.9
-  '@zardoy/vscode-utils': 0.0.29_ttuytxkt5mjh5hroqa2kysodem
+  '@zardoy/vscode-utils': 0.0.29_heruyoxwavtuopiyk2eaoewx3u
   change-case: 4.1.2
   escape-string-regexp: 5.0.0
   modify-json-file: 1.2.2
@@ -30,13 +30,13 @@ dependencies:
   postcss-selector-parser: 6.0.10
   rambda: 7.2.1
   type-fest: 2.19.0
-  vscode-framework: 0.0.18_3mrqqbobrla2lpxj6b2chqm2fq
+  vscode-framework: 0.0.18_wy2o72g5psyj5xfdkp23do5rva
   vscode-html-languageservice: 4.2.5
   vscode-uri: 3.0.3
 
 devDependencies:
   '@types/node': 17.0.45
-  '@types/vscode': 1.71.0
+  '@types/vscode': 1.72.0
   '@zardoy/tsconfig': 1.5.0_typescript@4.8.3
   eslint: 8.23.1
   eslint-config-zardoy: 0.2.11_irgkl5vooow2ydyo6aokmferha
@@ -467,8 +467,8 @@ packages:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
     dev: false
 
-  /@types/vscode/1.71.0:
-    resolution: {integrity: sha512-nB50bBC9H/x2CpwW9FzRRRDrTZ7G0/POttJojvN/LiVfzTGfLyQIje1L1QRMdFXK9G41k5UJN/1B9S4of7CSzA==}
+  /@types/vscode/1.72.0:
+    resolution: {integrity: sha512-WvHluhUo+lQvE3I4wUagRpnkHuysB4qSyOQUyIAS9n9PYMJjepzTUD8Jyks0YeXoPD0UGctjqp2u84/b3v6Ydw==}
 
   /@types/yauzl/2.10.0:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
@@ -655,7 +655,7 @@ packages:
       type-fest: 2.19.0
     dev: false
 
-  /@zardoy/vscode-utils/0.0.29_ttuytxkt5mjh5hroqa2kysodem:
+  /@zardoy/vscode-utils/0.0.29_heruyoxwavtuopiyk2eaoewx3u:
     resolution: {integrity: sha512-A7K3R66Wtl4biNdFdoRZWAXsV4EpjCip049dSy+MD6pBACBGp5OYOnPR81mrjLl0M5JpUzYLSwCoBp34Lulq/g==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
@@ -672,7 +672,7 @@ packages:
       vscode-framework:
         optional: true
     dependencies:
-      '@types/vscode': 1.71.0
+      '@types/vscode': 1.72.0
       '@zardoy/utils': 0.0.4
       chokidar: 3.5.3
       commander: 9.4.0
@@ -682,7 +682,7 @@ packages:
       rambda: 7.2.1
       typed-jsonfile: 0.2.1
       untildify: 4.0.0
-      vscode-framework: 0.0.18_3mrqqbobrla2lpxj6b2chqm2fq
+      vscode-framework: 0.0.18_wy2o72g5psyj5xfdkp23do5rva
       vscode-manifest: 0.0.8
       vscode-uri: 3.0.3
     dev: false
@@ -4026,7 +4026,7 @@ packages:
       type-fest: 2.19.0
     dev: false
 
-  /typed-vscode/0.0.5_3mrqqbobrla2lpxj6b2chqm2fq:
+  /typed-vscode/0.0.5_wy2o72g5psyj5xfdkp23do5rva:
     resolution: {integrity: sha512-BJpELW+Q35iWc6t/Na0ZGprG1jwGgFb3U+71UIDKjxEp+LZZKatMzoBSuPoO/saTeSzMY8YinGsglkgru8u9jg==}
     engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
@@ -4034,7 +4034,7 @@ packages:
     peerDependencies:
       '@types/vscode': ^1.62.0
     dependencies:
-      '@types/vscode': 1.71.0
+      '@types/vscode': 1.72.0
       code-block-writer: 11.0.3
       commander: 8.3.0
       cosmiconfig: 7.0.1
@@ -4169,17 +4169,17 @@ packages:
     resolution: {integrity: sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==}
     dev: false
 
-  /vscode-extra/0.0.4_@types+vscode@1.71.0:
+  /vscode-extra/0.0.4_@types+vscode@1.72.0:
     resolution: {integrity: sha512-dI435DBqb9VSGX0HpapJN5jSg3hXXU9y6hlmXIJAiI3sF2YpEZjC+aZncn1NkkuUmbT0IY19cQOjQiez8mmJ7A==}
     engines: {node: '"^12.20.0 || ^14.13.1 || >=16.0.0"'}
     peerDependencies:
       '@types/vscode': ^1.60.0
     dependencies:
-      '@types/vscode': 1.71.0
+      '@types/vscode': 1.72.0
       lodash: 4.17.21
     dev: false
 
-  /vscode-framework/0.0.18_3mrqqbobrla2lpxj6b2chqm2fq:
+  /vscode-framework/0.0.18_wy2o72g5psyj5xfdkp23do5rva:
     resolution: {integrity: sha512-9Vp/KVboUFtEGc7vKNXQb5YK1B27JBeZ67U+Yi5aH9ZvtM9fERydbL+n2p+GS2oGf9x3pyT2bEfF3j/sXojHig==}
     engines: {node: ^14.13.1 || >=16.0.0}
     hasBin: true
@@ -4188,7 +4188,7 @@ packages:
       '@types/vscode': ^1.58.1
     dependencies:
       '@prisma/debug': 3.15.2
-      '@types/vscode': 1.71.0
+      '@types/vscode': 1.72.0
       '@vscode/test-web': 0.0.15
       change-case: 4.1.2
       chokidar: 3.5.3
@@ -4212,9 +4212,9 @@ packages:
       pkg-dir: 5.0.0
       pretty-format: 27.5.1
       typed-jsonfile: 0.2.1
-      typed-vscode: 0.0.5_3mrqqbobrla2lpxj6b2chqm2fq
+      typed-vscode: 0.0.5_wy2o72g5psyj5xfdkp23do5rva
       typescript-json-schema: 0.51.0
-      vscode-extra: 0.0.4_@types+vscode@1.71.0
+      vscode-extra: 0.0.4_@types+vscode@1.72.0
       vscode-manifest: 0.0.8
       ws: 8.8.1
     transitivePeerDependencies:

--- a/src/configurationType.ts
+++ b/src/configurationType.ts
@@ -26,22 +26,23 @@ export type Configuration = {
      */
     enableAutoExpandTag: boolean
     /**
-     *  Whether to enable code action for quick store registration in computed field
-     *  @default true
-     */
-    enablePiniaStoreRegistrationCodeAction: boolean
-    /**
-     *
-     *  @default ".*?stores\\/.*"
-     */
-    piniaStorePathRegex: string
-    /**
      *  Copied component name case
      *  @default "preserve"
      */
     copyComponentNameCase: 'preserve' | 'camelCase'
     /**
-     *
+     *  Whether to enable code action for quick store registration in computed field
+     *  @default true
+     */
+    enablePiniaStoreRegistrationCodeAction: boolean
+    /**
+     *  Pinia stores import path
+     *  @default ".*?stores\\/.*"
+     */
+    piniaStorePathRegex: string
+    /**
+     *  (advanced): Invokes `String.prototype.replace` on the imported store name
+     *  Call signature: `<importedStoreName>.replace(new Regexp(pattern), replacement)`
      *  @default null
      */
     piniaStoreComputedNameTransform: null | { pattern: RegExp | string; replacement: string }

--- a/src/configurationType.ts
+++ b/src/configurationType.ts
@@ -32,7 +32,7 @@ export type Configuration = {
     enablePiniaStoreRegistrationCodeAction: boolean
     /**
      *
-     *  @default ".*?\/stores/.*"
+     *  @default ".*?stores\\/.*"
      */
     piniaStorePathRegex: string
     /**
@@ -40,4 +40,9 @@ export type Configuration = {
      *  @default "preserve"
      */
     copyComponentNameCase: 'preserve' | 'camelCase'
+    /**
+     *
+     *  @default null
+     */
+    piniaStoreComputedNameTransform: null | { pattern: RegExp | string; replacement: string }
 }

--- a/src/configurationType.ts
+++ b/src/configurationType.ts
@@ -26,6 +26,16 @@ export type Configuration = {
      */
     enableAutoExpandTag: boolean
     /**
+     *  Whether to enable code action for quick store registration in computed field
+     *  @default true
+     */
+    enablePiniaStoreRegistrationCodeAction: boolean
+    /**
+     *
+     *  @default ".*?\/stores/.*"
+     */
+    piniaStorePathRegex: string
+    /**
      *  Copied component name case
      *  @default "preserve"
      */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { registerFindReferences } from './findReferences'
 import { registerGotoDefinition } from './gotoDefinition'
 import { registerHover } from './hover'
 import { registerTemplateCompletion } from './templateCompletion'
+import { registerPiniaCodeactions } from './piniaCodeActions'
 import focusVuexMapper from './commands/focusVuexMapper'
 import { registerCopyComponentName } from './commands/copyComponentName'
 
@@ -22,4 +23,5 @@ export const activate = () => {
     registerCssClasesFromTemplate()
     focusVuexMapper()
     registerCopyComponentName()
+    registerPiniaCodeactions()
 }

--- a/src/piniaCodeActions.ts
+++ b/src/piniaCodeActions.ts
@@ -7,21 +7,32 @@ export const registerPiniaCodeactions = () => {
             const pos = range.start
             const codeActions = [] as vscode.CodeAction[]
 
-            const piniaStoreMatch = new RegExp(/(import (.+)\s+from )(['"].*pinia.*['"])/).exec(document.lineAt(pos.line).text)
+            const piniaStoreMatch = new RegExp(/(import (.+)\s+from )(['"].*pinia.*['"].?)/).exec(document.lineAt(pos.line).text)
 
             if (piniaStoreMatch) {
                 const computedOutline = await getComputedOutline(document.uri)
                 if (!computedOutline) return
 
                 const { range: computedRange } = computedOutline
-
-                const computedStoreTemplate = `\t${piniaStoreMatch[2]!}() {\n\t\t\treturn defineStore('${piniaStoreMatch[2]!}', ${piniaStoreMatch[2]!})()\n\t\t},\n\t`
+                const snippetStirng = // eslint-disable-next-line no-template-curly-in-string
+                    "\t${TM_CURRENT_LINE/import (.+)\\s+from ['\"].*?pinia.*?['\"].?/$1/}() {\n\t\treturn defineStore('$2', $3)()\n\t},$0\n"
 
                 const workspaceEdit = new vscode.WorkspaceEdit()
                 if (computedRange.isSingleLine)
                     // computed: {}; case
-                    workspaceEdit.insert(document.uri, computedRange.end.translate(undefined, -1), `\n\t${computedStoreTemplate}`)
-                else workspaceEdit.insert(document.uri, computedRange.start.translate(1), computedStoreTemplate)
+                    workspaceEdit.set(document.uri, [
+                        new vscode.SnippetTextEdit(
+                            new vscode.Range(computedRange.start, computedRange.end),
+                            new vscode.SnippetString(`computed: {\n${snippetStirng}}`),
+                        ),
+                    ])
+                else
+                    workspaceEdit.set(document.uri, [
+                        new vscode.SnippetTextEdit(
+                            new vscode.Range(computedRange.start.translate(1), computedRange.start.translate(1)),
+                            new vscode.SnippetString(snippetStirng),
+                        ),
+                    ])
 
                 codeActions.push({
                     title: 'Register pinia store in computed',

--- a/src/piniaCodeActions.ts
+++ b/src/piniaCodeActions.ts
@@ -15,9 +15,6 @@ export const registerPiniaCodeactions = () => {
 
                 const { range: computedRange } = computedOutline
 
-                console.log('document', document.getText(computedRange))
-                console.log('range.isSingleLine', computedRange.isSingleLine)
-
                 const computedStoreTemplate = `\t${piniaStoreMatch[2]!}() {\n\t\t\treturn defineStore('${piniaStoreMatch[2]!}', ${piniaStoreMatch[2]!})()\n\t\t},\n\t`
 
                 const workspaceEdit = new vscode.WorkspaceEdit()

--- a/src/piniaCodeActions.ts
+++ b/src/piniaCodeActions.ts
@@ -1,13 +1,17 @@
 import * as vscode from 'vscode'
+import { getExtensionSetting } from 'vscode-framework'
 import { getComputedOutline } from './util'
 
 export const registerPiniaCodeactions = () => {
     vscode.languages.registerCodeActionsProvider('vue', {
         async provideCodeActions(document, range, context, token) {
+            if (!getExtensionSetting('enablePiniaStoreRegistrationCodeAction')) return
+
             const pos = range.start
             const codeActions = [] as vscode.CodeAction[]
+            const piniaStorePathRegex = getExtensionSetting('piniaStorePathRegex')
 
-            const piniaStoreMatch = new RegExp(/(import (.+)\s+from )(['"].*pinia.*['"].?)/).exec(document.lineAt(pos.line).text)
+            const piniaStoreMatch = new RegExp(`(import (.+)\\s+from )(['"]${piniaStorePathRegex}['"].?)`).exec(document.lineAt(pos.line).text)
 
             if (piniaStoreMatch) {
                 const computedOutline = await getComputedOutline(document.uri)

--- a/src/piniaCodeActions.ts
+++ b/src/piniaCodeActions.ts
@@ -16,10 +16,15 @@ export const registerPiniaCodeactions = () => {
             if (piniaStoreMatch) {
                 const computedOutline = await getComputedOutline(document.uri)
                 if (!computedOutline) return
-
+                // const str = `\${TM_CURRENT_LINE/import (.+)\\s+from ['"]${piniaStorePathRegex}['"].?/$1/}`
                 const { range: computedRange } = computedOutline
-                const snippetStirng = // eslint-disable-next-line no-template-curly-in-string
-                    "\t${TM_CURRENT_LINE/import (.+)\\s+from ['\"].*?pinia.*?['\"].?/$1/}() {\n\t\treturn defineStore('$2', $3)()\n\t},$0\n"
+
+                const customNameTransform = getExtensionSetting('piniaStoreComputedNameTransform')
+                const computedName = customNameTransform
+                    ? piniaStoreMatch[2]!.replace(new RegExp(customNameTransform?.pattern), customNameTransform?.replacement)
+                    : piniaStoreMatch[2]!
+
+                const snippetStirng = `\t\${1:${computedName}}() {\n\t\treturn defineStore('\${2:${piniaStoreMatch[2]!}}', \${3:${piniaStoreMatch[2]!}})()\n\t},$0\n`
 
                 const workspaceEdit = new vscode.WorkspaceEdit()
                 if (computedRange.isSingleLine)

--- a/src/piniaCodeActions.ts
+++ b/src/piniaCodeActions.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode'
+import { getComputedOutline } from './util'
+
+export const registerPiniaCodeactions = () => {
+    vscode.languages.registerCodeActionsProvider('vue', {
+        async provideCodeActions(document, range, context, token) {
+            const pos = range.start
+            const codeActions = [] as vscode.CodeAction[]
+
+            const piniaStoreMatch = new RegExp(/(import (.+)\s+from )(['"].*pinia.*['"])/).exec(document.lineAt(pos.line).text)
+
+            if (piniaStoreMatch) {
+                const computedOutline = await getComputedOutline(document.uri)
+                if (!computedOutline) return
+
+                const { range: computedRange } = computedOutline
+
+                console.log('document', document.getText(computedRange))
+                console.log('range.isSingleLine', computedRange.isSingleLine)
+
+                const computedStoreTemplate = `\t${piniaStoreMatch[2]!}() {\n\t\t\treturn defineStore('${piniaStoreMatch[2]!}', ${piniaStoreMatch[2]!})()\n\t\t},\n\t`
+
+                const workspaceEdit = new vscode.WorkspaceEdit()
+                if (computedRange.isSingleLine)
+                    // computed: {}; case
+                    workspaceEdit.insert(document.uri, computedRange.end.translate(undefined, -1), `\n\t${computedStoreTemplate}`)
+                else workspaceEdit.insert(document.uri, computedRange.start.translate(1), computedStoreTemplate)
+
+                codeActions.push({
+                    title: 'Register pinia store in computed',
+                    kind: vscode.CodeActionKind.QuickFix,
+                    isPreferred: true,
+                    edit: workspaceEdit,
+                })
+            }
+
+            return codeActions
+        },
+    })
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,3 +22,16 @@ export const getComponentNameOutline = async (documentUri: vscode.Uri) => {
 
     return componentNameOutline
 }
+
+export const getComputedOutline = async (documentUri: vscode.Uri) => {
+    const outline = await getNormalizedVueOutline(documentUri)
+
+    const computedOutline = outline
+        ?.find(({ name }) => name === 'script')
+        ?.children.find(({ name }) => name === 'default')
+        ?.children.find(({ name }) => name === 'computed')
+
+    if (!computedOutline) console.warn("Can' get computed outline")
+
+    return computedOutline
+}


### PR DESCRIPTION
Just want a quick way for pinia store's registration in `computed`. 
This definitely lacks some customization - I'll add it if you aggree to merge this (I just need a minimal working tool for store registration as soon as possible)

*Current version demo:*

https://user-images.githubusercontent.com/74474615/219397049-242245ba-f124-4eb6-898f-bb50f48a0bbc.mp4



P.S. Can you give me a tip, if you have time? I wanted to add `vscode.SnippetString` in `workspaceEdit.insert()` method instead of plain string to have tabstops available for quick string configuration - smth like this 
```js
new vscode.SnippetString('$1() {\n\t\t\treturn defineStore(\'$2\', $3)()\n\t\t},\n\t'
```
, but it didn't work. Do I have a way to use snippets in code actions?
