### PR TITLE
feat: add copy component name command

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
             {
                 "command": "expandTag",
                 "title": "Expand Tag"
+            },
+            {
+                "command": "copyComponentName",
+                "title": "Copy Component Name"
             }
         ],
         "menus": {

--- a/src/commands/copyComponentName.ts
+++ b/src/commands/copyComponentName.ts
@@ -1,0 +1,24 @@
+import * as vscode from 'vscode'
+import { registerExtensionCommand, getExtensionSetting } from 'vscode-framework'
+import { camelCase } from 'change-case'
+import { getComponentNameOutline } from '../util'
+
+export const registerCopyComponentName = () => {
+    registerExtensionCommand('copyComponentName', async () => {
+        const activeEditor = vscode.window.activeTextEditor
+        if (!activeEditor) return
+
+        const componentNameOutline = await getComponentNameOutline(activeEditor?.document.uri)
+        if (!componentNameOutline) return
+
+        const { range } = componentNameOutline
+        const componentName = /name:\s+?["'](\w+?)["']/.exec(activeEditor.document.getText(range))![1] ?? ''
+
+        if (getExtensionSetting('copyComponentNameCase') === 'camelCase') {
+            await vscode.env.clipboard.writeText(camelCase(componentName))
+            return
+        }
+
+        await vscode.env.clipboard.writeText(componentName)
+    })
+}

--- a/src/configurationType.ts
+++ b/src/configurationType.ts
@@ -25,4 +25,9 @@ export type Configuration = {
      *  @default true
      */
     enableAutoExpandTag: boolean
+    /**
+     *  Copied component name case
+     *  @default "preserve"
+     */
+    copyComponentNameCase: 'preserve' | 'camelCase'
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { registerGotoDefinition } from './gotoDefinition'
 import { registerHover } from './hover'
 import { registerTemplateCompletion } from './templateCompletion'
 import focusVuexMapper from './commands/focusVuexMapper'
+import { registerCopyComponentName } from './commands/copyComponentName'
 
 export const activate = () => {
     registerFindReferences()
@@ -20,4 +21,5 @@ export const activate = () => {
     registerExpandTag()
     registerCssClasesFromTemplate()
     focusVuexMapper()
+    registerCopyComponentName()
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -6,7 +6,19 @@ export const interpolationPropRegex = /(?::|@|v-)([-\d\w.])+="([^"]*)$/
 export const getDefaultExportOutline = async (documentUri: vscode.Uri) => {
     const outline = await getNormalizedVueOutline(documentUri)
     const defaultExport = outline?.find(({ name }) => name === 'script')?.children.find(({ name }) => name === 'default')
-    if (!defaultExport) console.warn("Can' get default outline from Vetur")
+    if (!defaultExport) console.warn("Can't get default outline from Vetur")
 
     return defaultExport
+}
+
+export const getComponentNameOutline = async (documentUri: vscode.Uri) => {
+    const outline = await getNormalizedVueOutline(documentUri)
+    const componentNameOutline = outline
+        ?.find(({ name }) => name === 'script')
+        ?.children.find(({ name }) => name === 'default')
+        ?.children.find(({ name }) => name === 'name')
+
+    if (!componentNameOutline) console.warn("Can't get component name outline")
+
+    return componentNameOutline
 }


### PR DESCRIPTION
[Copy file name](https://github.com/zardoy/vscode-experiments/blob/0c92d7ebb665afa051b0a8ac6fa95b91bf97916a/src/features/copyFileName.ts) from vscode-experiments doesn't satisfy, when file name is just `index.vue`. This case is the primary reason for command implementation.